### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,5 @@
 changelog.txt
-README.txt
+readme.rst
 setup.py
 wmi.py
 wmitest.py

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(base_dir, "wmi.py"), "rb") as f:
 changes = ""
 
 TO_STRIP = set([":class:", ":mod:", ":meth:", ":func:", ":doc:"])
-with open(os.path.join(base_dir, "README.rst"), "rb") as f:
+with open(os.path.join(base_dir, "readme.rst"), "rb") as f:
     readme = f.read().decode("utf-8")
     for s in TO_STRIP:
         readme = readme.replace(s, "")


### PR DESCRIPTION
Include missing files in sdist for #11

Tested with

```
+++ mktemp -d
++ D=/tmp/tmp.wtljxqSI4f
++ trap 'rm -rf /tmp/tmp.wtljxqSI4f' EXIT
++ python -m venv /tmp/tmp.wtljxqSI4f
++ python setup.py sdist -d /tmp/tmp.wtljxqSI4f
running sdist
running egg_info
creating WMI.egg-info
writing WMI.egg-info/PKG-INFO
writing dependency_links to WMI.egg-info/dependency_links.txt
writing requirements to WMI.egg-info/requires.txt
writing top-level names to WMI.egg-info/top_level.txt
writing manifest file 'WMI.egg-info/SOURCES.txt'
reading manifest file 'WMI.egg-info/SOURCES.txt'
writing manifest file 'WMI.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating WMI-1.5.1
creating WMI-1.5.1/WMI.egg-info
copying files to WMI-1.5.1...
copying readme.rst -> WMI-1.5.1
copying setup.py -> WMI-1.5.1
copying wmi.py -> WMI-1.5.1
copying wmitest.cmd -> WMI-1.5.1
copying wmitest.master.ini -> WMI-1.5.1
copying wmitest.py -> WMI-1.5.1
copying wmiweb.py -> WMI-1.5.1
copying WMI.egg-info/PKG-INFO -> WMI-1.5.1/WMI.egg-info
copying WMI.egg-info/SOURCES.txt -> WMI-1.5.1/WMI.egg-info
copying WMI.egg-info/dependency_links.txt -> WMI-1.5.1/WMI.egg-info
copying WMI.egg-info/requires.txt -> WMI-1.5.1/WMI.egg-info
copying WMI.egg-info/top_level.txt -> WMI-1.5.1/WMI.egg-info
Writing WMI-1.5.1/setup.cfg
Creating tar archive
removing 'WMI-1.5.1' (and everything under it)
++ cd /
++ /tmp/tmp.wtljxqSI4f/bin/pip install /tmp/tmp.wtljxqSI4f/WMI-1.5.1.tar.gz
Processing /tmp/tmp.wtljxqSI4f/WMI-1.5.1.tar.gz
Collecting pywin32 (from WMI==1.5.1)
  ERROR: Could not find a version that satisfies the requirement pywin32 (from WMI==1.5.1) (from versions: none)
ERROR: No matching distribution found for pywin32 (from WMI==1.5.1)
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+++ rm -rf /tmp/tmp.wtljxqSI4f
```
