### PR TITLE
Fix python3 compatibility issue.

### DIFF
--- a/wmi.py
+++ b/wmi.py
@@ -847,19 +847,14 @@ class _wmi_class(_wmi_object):
         """Generate a csv listing all the instances of this class with the class
         name as a header.
         """
-        def _to_utf8(item):
-            if isinstance(item, unicode):
-                return item.encode("utf-8")
-            else:
-                return str(item)
         if filepath is None:
             filepath = self._class_name + ".csv"
         fields = list(p.Name for p in self.ole_object.Properties_)
-        with open(filepath, "wb") as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             writer = csv.writer(f)
             writer.writerow(fields)
             for instance in self.query():
-                writer.writerow([_to_utf8(getattr(instance, field)) for field in fields])
+                writer.writerow([str(getattr(instance, field)) for field in fields])
 
     def query(self, fields=[], **where_clause):
         """Make it slightly easier to query against the class,


### PR DESCRIPTION
Hi tjquk,
   First of all, thank you for taking the time to review and maintain this project.
   I found some issue while I trying to use `_wmi_class's to_csv()` function in python3.
# 1. TypeError: a bytes-like object is required, not 'str'
- I modify "wb" to "w". 
- [reference](https://stackoverflow.com/questions/33054527/typeerror-a-bytes-like-object-is-required-not-str-when-writing-to-a-file-in)
```python
>>> system.Win32_ComputerSystem.to_csv()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\mason\fix-wmi\wmi\wmi.py", line 860, in to_csv
    writer.writerow(fields)
TypeError: a bytes-like object is required, not 'str'
>>>
```

# 2. NameError: name 'unicode' is not defined
- I delete `_to_utf8()` and open with encoding="utf-8"
- [reference](https://stackoverflow.com/questions/36110598/nameerror-name-unicode-is-not-defined)
```python
>>> system.Win32_ComputerSystem.to_csv()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\mason\fix-wmi\wmi\wmi.py", line 862, in to_csv
    writer.writerow([_to_utf8(getattr(instance, field)) for field in fields])
  File "C:\Users\mason\fix-wmi\wmi\wmi.py", line 862, in <listcomp>
    writer.writerow([_to_utf8(getattr(instance, field)) for field in fields])
  File "C:\Users\mason\fix-wmi\wmi\wmi.py", line 851, in _to_utf8
    if isinstance(item, unicode):
NameError: name 'unicode' is not defined
>>>
```

    Hope you can take a review when you have time.
    Thank you.

Warm regards,
Mason