### PR TITLE
Sample code shows `Local Disk` only; skip others like `Network Drive`

### DIFF
--- a/wmi.py
+++ b/wmi.py
@@ -1500,6 +1500,6 @@ if __name__ == '__main__':
     system = WMI()
     for my_computer in system.Win32_ComputerSystem():
         print("Disks on %s" % my_computer.Name)
-        for disk in system.Win32_LogicalDisk():
+        for disk in system.Win32_LogicalDisk(DriveType=3):
             print("%s; %s; %s" % (disk.Caption, disk.Description, disk.ProviderName or ""))
 


### PR DESCRIPTION
Hi tjguk,

- I notice that when I run `py wmi.py`, the sample code of `if __name__ == __main__` will blocking my computer for a while.
- Turn out the reason is that I have `Network Drive` which is disconnect status.
- The `system.Win32_LogicalDisk()` will be taking about 30 secs to 1 min until timeout.
- I add `DriveType=3` as a condition to let it only shows Local Disk, so people won't stock while there's some special drive not accessible at the moment.
  - [DriveType](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-logicaldisk)

Warm regards,
Mason